### PR TITLE
Add Debian Under Windows Support

### DIFF
--- a/bountytpl
+++ b/bountytpl
@@ -68,6 +68,7 @@ report_parse () {
 
     _report=$(cat "${1}")
 
+
     _found=1
     _key=1
     _error=0
@@ -76,7 +77,12 @@ report_parse () {
         _found=$(echo "${_report}" | grep -m1 -Eo "{{[a-zA-Z0-9_-]+}}" | head -n 1 || echo "")
         [ "${_found}" == "" ] && break;
 
-        _find=$(echo "${_found}" | cut -c 3- | rev | cut -c 3- | rev)
+        if [ "$(uname)" == "Darwin" ]; then
+            _find=$(echo "${_found}" | cut -c 3- | rev | cut -c 3- | rev)
+        else
+            _find=$(echo "${_found}" | rev | cut -c 3- | rev)
+        fi
+
         _exists=$(echo "${_vars}" | jq -r --arg find "${_find}" 'has($find)')
         [ "${_exists}" == "false" ] && _error=1 && doc_error_notice "${_find} not found in variables"
 

--- a/bountytpl
+++ b/bountytpl
@@ -68,7 +68,6 @@ report_parse () {
 
     _report=$(cat "${1}")
 
-
     _found=1
     _key=1
     _error=0


### PR DESCRIPTION
Hi there,

When running debian under Windows:

```
$ cat /etc/debian_version 
9.6
$ uname -a
Linux hostname 4.4.0-17763-Microsoft #253-Microsoft Mon Dec 31 17:49:00 PST 2018 x86_64 GNU/Linux
```

The following output is produced with the examples you provided:

```
$ bountytpl test/example-report.md -f test/example-report.json
asset}}
### set not found in variables
domain}}
### main not found in variables
domain}}
### main not found in variables
lookup}}
### okup not found in variables
poc-before}}
### c-before not found in variables
```

This is probably due to some shenanigans with grep implementations. After this patch:

```
bountytpl test/example-report.md -f test/example-report.json
---
weakness: privilege escalation
asset: *.example.com
---

# Subdomain Takeover  mail.example.com pointing to unclaimed bucket in AWS S3

Hi,

I noticed that the following domain: `mail.example.com` was returning the following information:
[...]
```